### PR TITLE
Update Grunt File

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -29,7 +29,8 @@ module.exports = function(grunt) {
         options: {
           module: "commonjs",
           target: "es6",
-          sourceMap: false
+          sourceMap: false,
+          rootDir: "src"
         }
       }
     },


### PR DESCRIPTION
Running "ts:app" (ts) task
Compiling...
Using tsc v2.3.4
>> Warning: created src\.baseDir.ts file because `outDir` was specified in 
the Gruntfile ts `options`, but not `rootDir`.  Add `rootDir`  
under the task or target `options` object to fix this warning.