### PR TITLE
chore: correct spelling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -84,7 +84,7 @@ export class Server {
       extended: true
     }));
 
-    //mount cookie parker
+    //mount cookie parser middleware
     this.app.use(cookieParser("SECRET_GOES_HERE"));
 
     //mount override?


### PR DESCRIPTION
Additionally, the error also exists within the blog post examining this code: http://brianflove.com/2016/11/08/typescript-2-express-node/